### PR TITLE
Cu sparse similar to vector

### DIFF
--- a/lib/cusparse/conversions.jl
+++ b/lib/cusparse/conversions.jl
@@ -41,6 +41,8 @@ function SparseArrays.sparse(I::CuVector{Cint}, J::CuVector{Cint}, V::CuVector{T
     end
 end
 
+## Matrix to vector, no direct conversion
+CuSparseVector(Mat::AbstractCuSparseMatrix) = CuSparseVector(sparse(reshape(Mat,:)))
 
 ## CSR to CSC
 


### PR DESCRIPTION
Added method for colon indexing a CuSparseMatrix, and a conversion from CuSparseMatrix to CuSparseMatrix to vector. Fixed show method of vectors to be same as for SparseArrays.